### PR TITLE
Expose deletion_protection to users

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ resource "aws_db_instance" "main" {
   license_model             = "${var.license_model}"
   storage_encrypted         = "${var.storage_encrypted}"
   kms_key_id                = "${var.kms_key_id}"
+  deletion_protection       = "${var.deletion_protection}"
 
   apply_immediately = "${var.apply_immediately}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,11 @@ variable "database_name" {
   default     = "main"
 }
 
+variable "deletion_protection" {
+  description = "If the DB instance should have deletion protection enabled. The database can't be deleted when this value is set to true."
+  default     = false
+}
+
 variable "port" {
   description = "The port on which the DB accepts connections."
   default     = "5439"


### PR DESCRIPTION
Expose `deletion_protection` to users so that they can create deletion-protected databases.