### PR TITLE
 Add support for specifying the identifier of the CA certificate for the DB instance.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "random_string" "suffix" {
 }
 
 resource "aws_db_instance" "main" {
-  depends_on                = ["aws_db_subnet_group.main"]
+  depends_on                = [aws_db_subnet_group.main]
   identifier                = "${var.name_prefix}-db"
   name                      = var.database_name
   username                  = var.username
@@ -61,6 +61,7 @@ resource "aws_security_group" "main" {
 
 resource "aws_security_group_rule" "egress" {
   security_group_id = aws_security_group.main.id
+  description       = "Terraformed security group."
   type              = "egress"
   protocol          = "-1"
   from_port         = 0

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ resource "aws_db_instance" "main" {
   storage_encrypted         = var.storage_encrypted
   kms_key_id                = var.kms_key_id
   deletion_protection       = var.deletion_protection
+  ca_cert_identifier        = var.ca_cert_identifier
 
   apply_immediately = var.apply_immediately
 

--- a/variables.tf
+++ b/variables.tf
@@ -164,3 +164,9 @@ variable "kms_key_id" {
   type        = string
   default     = ""
 }
+
+variable "ca_cert_identifier" {
+  description = "Specifies the identifier of the CA certificate for the DB instance."
+  type        = string
+  default     = "rds-ca-2015"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -168,5 +168,5 @@ variable "kms_key_id" {
 variable "ca_cert_identifier" {
   description = "Specifies the identifier of the CA certificate for the DB instance."
   type        = string
-  default     = "rds-ca-2015"
+  default     = "rds-ca-2019"
 }


### PR DESCRIPTION
This resolves #20 

* Added support for [ca_cert_identifier](https://www.terraform.io/docs/providers/aws/d/db_instance.html#ca_cert_identifier) with default `rds-ca-2015` which should be updated to `rds-ca-2019` after February 5th 2020.

See the following [article](https://aws.amazon.com/blogs/database/amazon-rds-customers-update-your-ssl-tls-certificates-by-february-5-2020/)