### PR TITLE
Replace deprecated field (`name`) with `db_name`.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "random_string" "suffix" {
 resource "aws_db_instance" "main" {
   depends_on                = [aws_db_subnet_group.main]
   identifier                = "${var.name_prefix}-db"
-  name                      = var.database_name
+  db_name                   = var.database_name
   username                  = var.username
   password                  = var.password
   port                      = var.port

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,5 +48,5 @@ output "username" {
 
 output "database_name" {
   description = "The database name."
-  value       = aws_db_instance.main.name
+  value       = aws_db_instance.main.db_name
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 0.14"
+
+  required_providers {
+    aws = {
+      version = ">= 4"
+    }
+  }
 }


### PR DESCRIPTION
Requires aws-provider version above 4.

This resolves #31